### PR TITLE
Add preferences.svg to plasma theme

### DIFF
--- a/plasma/desktoptheme/Arc-Color/icons/preferences.svg
+++ b/plasma/desktoptheme/Arc-Color/icons/preferences.svg
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 22 22"
+   id="svg"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   width="100%"
+   height="100%"
+   sodipodi:docname="preferences.svg">
+  <defs
+     id="defs81">
+    <style
+       id="current-color-scheme"
+       type="text/css">
+      .ColorScheme-Text {
+        color:#7B7C7E;
+      }
+      .ColorScheme-Background{
+        color:#EFF0F1;
+      }
+      .ColorScheme-Highlight{
+        color:#3DAEE6;
+      }
+      .ColorScheme-ViewText {
+        color:#7B7C7E;
+      }
+      .ColorScheme-ViewBackground{
+        color:#FCFCFC;
+      }
+      .ColorScheme-ViewHover {
+        color:#3DAEE6;
+      }
+      .ColorScheme-ViewFocus{
+        color:#1E92FF;
+      }
+      .ColorScheme-ButtonText {
+        color:#7B7C7E;
+      }
+      .ColorScheme-ButtonBackground{
+        color:#EFF0F1;
+      }
+      .ColorScheme-ButtonHover {
+        color:#3DAEE6;
+      }
+      .ColorScheme-ButtonFocus{
+        color:#1E92FF;
+      }
+</style>
+  </defs>
+  <metadata
+     id="metadata34">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1600"
+     inkscape:window-height="805"
+     id="namedview32"
+     showgrid="true"
+     inkscape:zoom="3.24"
+     inkscape:cx="60.592077"
+     inkscape:cy="-55.587165"
+     inkscape:window-x="40"
+     inkscape:window-y="1050"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg"
+     borderlayer="true"
+     showguides="false"
+     inkscape:guide-bbox="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-global="true"
+     inkscape:bbox-nodes="true"
+     showborder="true">
+    <sodipodi:guide
+       orientation="0,1"
+       position="23,19"
+       id="guide3820" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="24,3"
+       id="guide3822" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="11,10"
+       id="guide3824" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="21,11"
+       id="guide3826" />
+  </sodipodi:namedview>
+  <g
+     id="preferences-system-bluetooth"
+     transform="translate(40,78)">
+    <rect
+       style="fill:#ffffff;fill-opacity:0;stroke:none"
+       id="rect3009"
+       width="22"
+       height="22"
+       x="1"
+       y="1" />
+    <path
+       id="rect2996"
+       d="m 11,4 0,6 -3,-3 0,2 3,3 -3,3 0,2 3,-3 0,6 2,-2 3,-3 -3,-3 3,-3 -3,-3 -2,-2 z m 1,3 2,2 -2,2 0,-4 z m 0,6 2,2 -2,2 0,-4 z"
+       style="fill:#d3dae3;fill-opacity:1;opacity:1"
+       inkscape:connector-curvature="0"
+       class="ColorScheme-Text" />
+  </g>
+  <g
+     transform="translate(80,78)"
+     id="preferences-system-bluetooth-inactive">
+    <rect
+       y="1"
+       x="1"
+       height="22"
+       width="22"
+       id="rect3007"
+       style="fill:#ffffff;fill-opacity:0;stroke:none" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.3;fill:#d3dae3;fill-opacity:1"
+       d="m 11,4 0,6 -3,-3 0,2 3,3 -3,3 0,2 3,-3 0,6 2,-2 3,-3 -3,-3 3,-3 -3,-3 -2,-2 z m 1,3 2,2 -2,2 0,-4 z m 0,6 2,2 -2,2 0,-4 z"
+       id="path3009"
+       class="ColorScheme-Text" />
+  </g>
+  <g
+     id="preferences-system-bluetooth-activated"
+     transform="translate(0,78)">
+    <rect
+       y="1"
+       x="1"
+       height="22"
+       width="22"
+       id="rect3783"
+       style="fill:#ffffff;fill-opacity:0;stroke:none" />
+    <path
+       style="fill:#d3dae3;fill-opacity:1;opacity:1"
+       d="m 11,4 0,6 -3,-3 0,2 3,3 -3,3 0,2 3,-3 0,6 2,-2 3,-3 L 13,12 16,9 13,6 11,4 z M 4,5 C 3.4477153,5 3,5.4477153 3,6 3,6.5522847 3.4477153,7 4,7 4.5522847,7 5,6.5522847 5,6 5,5.4477153 4.5522847,5 4,5 z m 16,0 c -0.552285,0 -1,0.4477153 -1,1 0,0.5522847 0.447715,1 1,1 0.552285,0 1,-0.4477153 1,-1 0,-0.5522847 -0.447715,-1 -1,-1 z m -8,2 2,2 -2,2 0,-4 z m -8,4 c -0.5522847,0 -1,0.447715 -1,1 0,0.552285 0.4477153,1 1,1 0.5522847,0 1,-0.447715 1,-1 0,-0.552285 -0.4477153,-1 -1,-1 z m 16,0 c -0.552285,0 -1,0.447715 -1,1 0,0.552285 0.447715,1 1,1 0.552285,0 1,-0.447715 1,-1 0,-0.552285 -0.447715,-1 -1,-1 z m -8,2 2,2 -2,2 0,-4 z m -8,4 c -0.5522847,0 -1,0.447715 -1,1 0,0.552285 0.4477153,1 1,1 0.5522847,0 1,-0.447715 1,-1 0,-0.552285 -0.4477153,-1 -1,-1 z m 16,0 c -0.552285,0 -1,0.447715 -1,1 0,0.552285 0.447715,1 1,1 0.552285,0 1,-0.447715 1,-1 0,-0.552285 -0.447715,-1 -1,-1 z"
+       id="path3785"
+       inkscape:connector-curvature="0"
+       class="ColorScheme-Text" />
+  </g>
+  <g
+     id="preferences-desktop-display-randr"
+     transform="translate(-1,-1)">
+    <rect
+       style="fill:#ffffff;fill-opacity:0;stroke:none"
+       id="rect3832"
+       width="22"
+       height="22"
+       x="1"
+       y="1" />
+    <path
+       id="rect7235"
+       style="color:#7b7c7e;opacity:1;fill:#d3dae3;fill-opacity:1;stroke:none"
+       d="m 7.0000091,19.999986 10.0000179,0 0,1.000014 -10.0000179,0 z m 3.0000049,-1.999998 3.999994,0 0,1.999983 -3.999994,0 z M 2,4.0000055 2,17.999973 l 19.999999,0 0,-13.9999675 z m 0.9999988,0.999999 18.0000012,0 0,9.9999725 -18.0000012,0 z"
+       class="ColorScheme-Text"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccc" />
+    <path
+       style="color:#7b7c7e;opacity:0.72000002;fill:#d3dae3;fill-opacity:1;stroke:none"
+       d="m 4,10 4,4 -4,0 z"
+       id="rect3018"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       class="ColorScheme-Text" />
+    <path
+       class="ColorScheme-Text"
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="path3028"
+       d="M 20,10 16,6 20,6 Z"
+       style="color:#7b7c7e;opacity:0.72000002;fill:#d3dae3;fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     id="preferences-desktop-notification"
+     transform="translate(-1,39)">
+    <rect
+       y="1"
+       x="1"
+       height="22"
+       width="22"
+       id="rect3068"
+       style="fill:#ffffff;fill-opacity:0;stroke:none" />
+    <rect
+       style="fill:#db3c30;fill-opacity:1;stroke:none"
+       id="rect4130-82-0"
+       width="15.999978"
+       height="15.999987"
+       x="4.000011"
+       y="4"
+       ry="7.999989" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#fcfcfc;fill-opacity:1;stroke:none"
+       d="m 11.202644,7.1999826 -0.0026,7.2000124 1.599998,0 0.0026,-7.2000124 z m 0.799999,7.9999894 c -0.441822,0 -0.799999,0.358171 -0.799999,0.799999 0,0.441827 0.358177,0.799999 0.799999,0.799999 0.441822,0 0.799999,-0.358172 0.799999,-0.799999 0,-0.441828 -0.358177,-0.799999 -0.799999,-0.799999 z"
+       id="rect4142-6"
+       sodipodi:nodetypes="cccccsssss" />
+  </g>
+</svg>

--- a/plasma/desktoptheme/Arc-Color/icons/preferences.svg
+++ b/plasma/desktoptheme/Arc-Color/icons/preferences.svg
@@ -5,55 +5,13 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    viewBox="0 0 22 22"
    id="svg"
    version="1.1"
    inkscape:version="0.91 r13725"
    width="100%"
-   height="100%"
-   sodipodi:docname="preferences.svg">
-  <defs
-     id="defs81">
-    <style
-       id="current-color-scheme"
-       type="text/css">
-      .ColorScheme-Text {
-        color:#7B7C7E;
-      }
-      .ColorScheme-Background{
-        color:#EFF0F1;
-      }
-      .ColorScheme-Highlight{
-        color:#3DAEE6;
-      }
-      .ColorScheme-ViewText {
-        color:#7B7C7E;
-      }
-      .ColorScheme-ViewBackground{
-        color:#FCFCFC;
-      }
-      .ColorScheme-ViewHover {
-        color:#3DAEE6;
-      }
-      .ColorScheme-ViewFocus{
-        color:#1E92FF;
-      }
-      .ColorScheme-ButtonText {
-        color:#7B7C7E;
-      }
-      .ColorScheme-ButtonBackground{
-        color:#EFF0F1;
-      }
-      .ColorScheme-ButtonHover {
-        color:#3DAEE6;
-      }
-      .ColorScheme-ButtonFocus{
-        color:#1E92FF;
-      }
-</style>
-  </defs>
+   height="100%">
   <metadata
      id="metadata34">
     <rdf:RDF>
@@ -62,61 +20,23 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1600"
-     inkscape:window-height="805"
-     id="namedview32"
-     showgrid="true"
-     inkscape:zoom="3.24"
-     inkscape:cx="60.592077"
-     inkscape:cy="-55.587165"
-     inkscape:window-x="40"
-     inkscape:window-y="1050"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg"
-     borderlayer="true"
-     showguides="false"
-     inkscape:guide-bbox="true"
-     inkscape:snap-bbox="true"
-     inkscape:snap-nodes="true"
-     inkscape:snap-bbox-edge-midpoints="true"
-     inkscape:snap-global="true"
-     inkscape:bbox-nodes="true"
-     showborder="true">
-    <sodipodi:guide
-       orientation="0,1"
-       position="23,19"
-       id="guide3820" />
-    <sodipodi:guide
-       orientation="0,1"
-       position="24,3"
-       id="guide3822" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="11,10"
-       id="guide3824" />
-    <sodipodi:guide
-       orientation="0,1"
-       position="21,11"
-       id="guide3826" />
-  </sodipodi:namedview>
+  <defs
+     id="defs7386">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#d3dae3; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+   </style>
+  </defs>
   <g
      id="preferences-system-bluetooth"
-     transform="translate(40,78)">
+     transform="translate(40,79)">
     <rect
-       style="fill:#ffffff;fill-opacity:0;stroke:none"
+       style="fill:currentColor;fill-opacity:0;stroke:none"
        id="rect3009"
        width="22"
        height="22"
@@ -124,13 +44,13 @@
        y="1" />
     <path
        id="rect2996"
+	   class="ColorScheme-Text"
        d="m 11,4 0,6 -3,-3 0,2 3,3 -3,3 0,2 3,-3 0,6 2,-2 3,-3 -3,-3 3,-3 -3,-3 -2,-2 z m 1,3 2,2 -2,2 0,-4 z m 0,6 2,2 -2,2 0,-4 z"
-       style="fill:#d3dae3;fill-opacity:1;opacity:1"
-       inkscape:connector-curvature="0"
-       class="ColorScheme-Text" />
+       style="opacity:1;fill:currentColor;fill-opacity:1"
+       inkscape:connector-curvature="0" />
   </g>
   <g
-     transform="translate(80,78)"
+     transform="translate(80,79)"
      id="preferences-system-bluetooth-inactive">
     <rect
        y="1"
@@ -138,36 +58,36 @@
        height="22"
        width="22"
        id="rect3007"
-       style="fill:#ffffff;fill-opacity:0;stroke:none" />
+       style="fill:currentColor;fill-opacity:0;stroke:none" />
     <path
+	   class="ColorScheme-Text"
        inkscape:connector-curvature="0"
-       style="opacity:0.3;fill:#d3dae3;fill-opacity:1"
+       style="opacity:0.3;fill:currentColor;fill-opacity:1"
        d="m 11,4 0,6 -3,-3 0,2 3,3 -3,3 0,2 3,-3 0,6 2,-2 3,-3 -3,-3 3,-3 -3,-3 -2,-2 z m 1,3 2,2 -2,2 0,-4 z m 0,6 2,2 -2,2 0,-4 z"
-       id="path3009"
-       class="ColorScheme-Text" />
+       id="path3009" />
   </g>
   <g
      id="preferences-system-bluetooth-activated"
-     transform="translate(0,78)">
+     transform="translate(0,79)">
     <rect
        y="1"
        x="1"
        height="22"
        width="22"
        id="rect3783"
-       style="fill:#ffffff;fill-opacity:0;stroke:none" />
+       style="fill:currentColor;fill-opacity:0;stroke:none" />
     <path
-       style="fill:#d3dae3;fill-opacity:1;opacity:1"
-       d="m 11,4 0,6 -3,-3 0,2 3,3 -3,3 0,2 3,-3 0,6 2,-2 3,-3 L 13,12 16,9 13,6 11,4 z M 4,5 C 3.4477153,5 3,5.4477153 3,6 3,6.5522847 3.4477153,7 4,7 4.5522847,7 5,6.5522847 5,6 5,5.4477153 4.5522847,5 4,5 z m 16,0 c -0.552285,0 -1,0.4477153 -1,1 0,0.5522847 0.447715,1 1,1 0.552285,0 1,-0.4477153 1,-1 0,-0.5522847 -0.447715,-1 -1,-1 z m -8,2 2,2 -2,2 0,-4 z m -8,4 c -0.5522847,0 -1,0.447715 -1,1 0,0.552285 0.4477153,1 1,1 0.5522847,0 1,-0.447715 1,-1 0,-0.552285 -0.4477153,-1 -1,-1 z m 16,0 c -0.552285,0 -1,0.447715 -1,1 0,0.552285 0.447715,1 1,1 0.552285,0 1,-0.447715 1,-1 0,-0.552285 -0.447715,-1 -1,-1 z m -8,2 2,2 -2,2 0,-4 z m -8,4 c -0.5522847,0 -1,0.447715 -1,1 0,0.552285 0.4477153,1 1,1 0.5522847,0 1,-0.447715 1,-1 0,-0.552285 -0.4477153,-1 -1,-1 z m 16,0 c -0.552285,0 -1,0.447715 -1,1 0,0.552285 0.447715,1 1,1 0.552285,0 1,-0.447715 1,-1 0,-0.552285 -0.447715,-1 -1,-1 z"
+       style="opacity:1;fill:currentColor;fill-opacity:1"
+       d="m 11,4 0,6 -3,-3 0,2 3,3 -3,3 0,2 3,-3 0,6 2,-2 3,-3 L 13,12 16,9 13,6 11,4 Z M 4,5 C 3.4477153,5 3,5.4477153 3,6 3,6.5522847 3.4477153,7 4,7 4.5522847,7 5,6.5522847 5,6 5,5.4477153 4.5522847,5 4,5 Z m 16,0 c -0.552285,0 -1,0.4477153 -1,1 0,0.5522847 0.447715,1 1,1 0.552285,0 1,-0.4477153 1,-1 0,-0.5522847 -0.447715,-1 -1,-1 z m -8,2 2,2 -2,2 0,-4 z m -8,4 c -0.5522847,0 -1,0.447715 -1,1 0,0.552285 0.4477153,1 1,1 0.5522847,0 1,-0.447715 1,-1 0,-0.552285 -0.4477153,-1 -1,-1 z m 16,0 c -0.552285,0 -1,0.447715 -1,1 0,0.552285 0.447715,1 1,1 0.552285,0 1,-0.447715 1,-1 0,-0.552285 -0.447715,-1 -1,-1 z m -8,2 2,2 -2,2 0,-4 z m -8,4 c -0.5522847,0 -1,0.447715 -1,1 0,0.552285 0.4477153,1 1,1 0.5522847,0 1,-0.447715 1,-1 0,-0.552285 -0.4477153,-1 -1,-1 z m 16,0 c -0.552285,0 -1,0.447715 -1,1 0,0.552285 0.447715,1 1,1 0.552285,0 1,-0.447715 1,-1 0,-0.552285 -0.447715,-1 -1,-1 z"
        id="path3785"
-       inkscape:connector-curvature="0"
-       class="ColorScheme-Text" />
+	   class="ColorScheme-Text"
+       inkscape:connector-curvature="0" />
   </g>
   <g
      id="preferences-desktop-display-randr"
      transform="translate(-1,-1)">
     <rect
-       style="fill:#ffffff;fill-opacity:0;stroke:none"
+       style="fill:currentColor;fill-opacity:0;stroke:none"
        id="rect3832"
        width="22"
        height="22"
@@ -175,49 +95,26 @@
        y="1" />
     <path
        id="rect7235"
-       style="color:#7b7c7e;opacity:1;fill:#d3dae3;fill-opacity:1;stroke:none"
+       style="fill:currentColor;fill-opacity:1;stroke:none"
        d="m 7.0000091,19.999986 10.0000179,0 0,1.000014 -10.0000179,0 z m 3.0000049,-1.999998 3.999994,0 0,1.999983 -3.999994,0 z M 2,4.0000055 2,17.999973 l 19.999999,0 0,-13.9999675 z m 0.9999988,0.999999 18.0000012,0 0,9.9999725 -18.0000012,0 z"
-       class="ColorScheme-Text"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccccccccccccc" />
+	   class="ColorScheme-Text"
+       inkscape:connector-curvature="0" />
     <path
-       style="color:#7b7c7e;opacity:0.72000002;fill:#d3dae3;fill-opacity:1;stroke:none"
+       style="fill:currentColor;fill-opacity:1;stroke:none"
        d="m 4,10 4,4 -4,0 z"
        id="rect3018"
        inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc"
-       class="ColorScheme-Text" />
+	   class="ColorScheme-Text" />
     <path
-       class="ColorScheme-Text"
-       sodipodi:nodetypes="cccc"
        inkscape:connector-curvature="0"
        id="path3028"
        d="M 20,10 16,6 20,6 Z"
-       style="color:#7b7c7e;opacity:0.72000002;fill:#d3dae3;fill-opacity:1;stroke:none" />
+	   class="ColorScheme-Text"
+       style="fill:currentColor;fill-opacity:1;stroke:none" />
   </g>
-  <g
-     id="preferences-desktop-notification"
-     transform="translate(-1,39)">
-    <rect
-       y="1"
-       x="1"
-       height="22"
-       width="22"
-       id="rect3068"
-       style="fill:#ffffff;fill-opacity:0;stroke:none" />
-    <rect
-       style="fill:#db3c30;fill-opacity:1;stroke:none"
-       id="rect4130-82-0"
-       width="15.999978"
-       height="15.999987"
-       x="4.000011"
-       y="4"
-       ry="7.999989" />
-    <path
-       inkscape:connector-curvature="0"
-       style="fill:#fcfcfc;fill-opacity:1;stroke:none"
-       d="m 11.202644,7.1999826 -0.0026,7.2000124 1.599998,0 0.0026,-7.2000124 z m 0.799999,7.9999894 c -0.441822,0 -0.799999,0.358171 -0.799999,0.799999 0,0.441827 0.358177,0.799999 0.799999,0.799999 0.441822,0 0.799999,-0.358172 0.799999,-0.799999 0,-0.441828 -0.358177,-0.799999 -0.799999,-0.799999 z"
-       id="rect4142-6"
-       sodipodi:nodetypes="cccccsssss" />
-  </g>
+  <g id="preferences-desktop-notification">
+	<rect y="40" x="0" height="22" width="22" id="rect3068" style="opacity:0;fill:currentColor;fill-opacity:0.94117647;stroke:none"/>
+	<path id="path4238" d="m 11,43 c -4.418278,0 -8,3.581722 -8,8 0,4.418278 3.581722,8 8,8 4.418278,0 8,-3.581722 8,-8 0,-4.418278 -3.581722,-8 -8,-8 z" style="opacity:1;fill:currentColor;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" class="ColorScheme-Highlight"/>
+	<path id="path4173-0" d="M 10 47 L 10 53 L 12 53 L 12 47 L 10 47 z M 11 54 C 10.546848 54 10 54.518427 10 54.980469 C 10 55.442512 10.546848 56 11 56 C 11.453152 56 12 55.442512 12 54.980469 C 12 54.518427 11.453152 54 11 54 z" style="opacity:1;fill:currentColor;fill-opacity:0.94117647;stroke:none" class="ColorScheme-Text"/>
+ </g>
 </svg>

--- a/plasma/desktoptheme/Arc-Dark/icons/preferences.svg
+++ b/plasma/desktoptheme/Arc-Dark/icons/preferences.svg
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 22 22"
+   id="svg"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   width="100%"
+   height="100%"
+   sodipodi:docname="preferences.svg">
+  <defs
+     id="defs81">
+    <style
+       id="current-color-scheme"
+       type="text/css">
+      .ColorScheme-Text {
+        color:#7B7C7E;
+      }
+      .ColorScheme-Background{
+        color:#EFF0F1;
+      }
+      .ColorScheme-Highlight{
+        color:#3DAEE6;
+      }
+      .ColorScheme-ViewText {
+        color:#7B7C7E;
+      }
+      .ColorScheme-ViewBackground{
+        color:#FCFCFC;
+      }
+      .ColorScheme-ViewHover {
+        color:#3DAEE6;
+      }
+      .ColorScheme-ViewFocus{
+        color:#1E92FF;
+      }
+      .ColorScheme-ButtonText {
+        color:#7B7C7E;
+      }
+      .ColorScheme-ButtonBackground{
+        color:#EFF0F1;
+      }
+      .ColorScheme-ButtonHover {
+        color:#3DAEE6;
+      }
+      .ColorScheme-ButtonFocus{
+        color:#1E92FF;
+      }
+</style>
+  </defs>
+  <metadata
+     id="metadata34">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1600"
+     inkscape:window-height="805"
+     id="namedview32"
+     showgrid="true"
+     inkscape:zoom="3.24"
+     inkscape:cx="60.592077"
+     inkscape:cy="-55.587165"
+     inkscape:window-x="40"
+     inkscape:window-y="1050"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg"
+     borderlayer="true"
+     showguides="false"
+     inkscape:guide-bbox="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-global="true"
+     inkscape:bbox-nodes="true"
+     showborder="true">
+    <sodipodi:guide
+       orientation="0,1"
+       position="23,19"
+       id="guide3820" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="24,3"
+       id="guide3822" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="11,10"
+       id="guide3824" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="21,11"
+       id="guide3826" />
+  </sodipodi:namedview>
+  <g
+     id="preferences-system-bluetooth"
+     transform="translate(40,78)">
+    <rect
+       style="fill:#ffffff;fill-opacity:0;stroke:none"
+       id="rect3009"
+       width="22"
+       height="22"
+       x="1"
+       y="1" />
+    <path
+       id="rect2996"
+       d="m 11,4 0,6 -3,-3 0,2 3,3 -3,3 0,2 3,-3 0,6 2,-2 3,-3 -3,-3 3,-3 -3,-3 -2,-2 z m 1,3 2,2 -2,2 0,-4 z m 0,6 2,2 -2,2 0,-4 z"
+       style="fill:#d3dae3;fill-opacity:1;opacity:1"
+       inkscape:connector-curvature="0"
+       class="ColorScheme-Text" />
+  </g>
+  <g
+     transform="translate(80,78)"
+     id="preferences-system-bluetooth-inactive">
+    <rect
+       y="1"
+       x="1"
+       height="22"
+       width="22"
+       id="rect3007"
+       style="fill:#ffffff;fill-opacity:0;stroke:none" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.3;fill:#d3dae3;fill-opacity:1"
+       d="m 11,4 0,6 -3,-3 0,2 3,3 -3,3 0,2 3,-3 0,6 2,-2 3,-3 -3,-3 3,-3 -3,-3 -2,-2 z m 1,3 2,2 -2,2 0,-4 z m 0,6 2,2 -2,2 0,-4 z"
+       id="path3009"
+       class="ColorScheme-Text" />
+  </g>
+  <g
+     id="preferences-system-bluetooth-activated"
+     transform="translate(0,78)">
+    <rect
+       y="1"
+       x="1"
+       height="22"
+       width="22"
+       id="rect3783"
+       style="fill:#ffffff;fill-opacity:0;stroke:none" />
+    <path
+       style="fill:#d3dae3;fill-opacity:1;opacity:1"
+       d="m 11,4 0,6 -3,-3 0,2 3,3 -3,3 0,2 3,-3 0,6 2,-2 3,-3 L 13,12 16,9 13,6 11,4 z M 4,5 C 3.4477153,5 3,5.4477153 3,6 3,6.5522847 3.4477153,7 4,7 4.5522847,7 5,6.5522847 5,6 5,5.4477153 4.5522847,5 4,5 z m 16,0 c -0.552285,0 -1,0.4477153 -1,1 0,0.5522847 0.447715,1 1,1 0.552285,0 1,-0.4477153 1,-1 0,-0.5522847 -0.447715,-1 -1,-1 z m -8,2 2,2 -2,2 0,-4 z m -8,4 c -0.5522847,0 -1,0.447715 -1,1 0,0.552285 0.4477153,1 1,1 0.5522847,0 1,-0.447715 1,-1 0,-0.552285 -0.4477153,-1 -1,-1 z m 16,0 c -0.552285,0 -1,0.447715 -1,1 0,0.552285 0.447715,1 1,1 0.552285,0 1,-0.447715 1,-1 0,-0.552285 -0.447715,-1 -1,-1 z m -8,2 2,2 -2,2 0,-4 z m -8,4 c -0.5522847,0 -1,0.447715 -1,1 0,0.552285 0.4477153,1 1,1 0.5522847,0 1,-0.447715 1,-1 0,-0.552285 -0.4477153,-1 -1,-1 z m 16,0 c -0.552285,0 -1,0.447715 -1,1 0,0.552285 0.447715,1 1,1 0.552285,0 1,-0.447715 1,-1 0,-0.552285 -0.447715,-1 -1,-1 z"
+       id="path3785"
+       inkscape:connector-curvature="0"
+       class="ColorScheme-Text" />
+  </g>
+  <g
+     id="preferences-desktop-display-randr"
+     transform="translate(-1,-1)">
+    <rect
+       style="fill:#ffffff;fill-opacity:0;stroke:none"
+       id="rect3832"
+       width="22"
+       height="22"
+       x="1"
+       y="1" />
+    <path
+       id="rect7235"
+       style="color:#7b7c7e;opacity:1;fill:#d3dae3;fill-opacity:1;stroke:none"
+       d="m 7.0000091,19.999986 10.0000179,0 0,1.000014 -10.0000179,0 z m 3.0000049,-1.999998 3.999994,0 0,1.999983 -3.999994,0 z M 2,4.0000055 2,17.999973 l 19.999999,0 0,-13.9999675 z m 0.9999988,0.999999 18.0000012,0 0,9.9999725 -18.0000012,0 z"
+       class="ColorScheme-Text"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccc" />
+    <path
+       style="color:#7b7c7e;opacity:0.72000002;fill:#d3dae3;fill-opacity:1;stroke:none"
+       d="m 4,10 4,4 -4,0 z"
+       id="rect3018"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       class="ColorScheme-Text" />
+    <path
+       class="ColorScheme-Text"
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="path3028"
+       d="M 20,10 16,6 20,6 Z"
+       style="color:#7b7c7e;opacity:0.72000002;fill:#d3dae3;fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     id="preferences-desktop-notification"
+     transform="translate(-1,39)">
+    <rect
+       y="1"
+       x="1"
+       height="22"
+       width="22"
+       id="rect3068"
+       style="fill:#ffffff;fill-opacity:0;stroke:none" />
+    <rect
+       style="fill:#db3c30;fill-opacity:1;stroke:none"
+       id="rect4130-82-0"
+       width="15.999978"
+       height="15.999987"
+       x="4.000011"
+       y="4"
+       ry="7.999989" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#fcfcfc;fill-opacity:1;stroke:none"
+       d="m 11.202644,7.1999826 -0.0026,7.2000124 1.599998,0 0.0026,-7.2000124 z m 0.799999,7.9999894 c -0.441822,0 -0.799999,0.358171 -0.799999,0.799999 0,0.441827 0.358177,0.799999 0.799999,0.799999 0.441822,0 0.799999,-0.358172 0.799999,-0.799999 0,-0.441828 -0.358177,-0.799999 -0.799999,-0.799999 z"
+       id="rect4142-6"
+       sodipodi:nodetypes="cccccsssss" />
+  </g>
+</svg>

--- a/plasma/desktoptheme/Arc-Dark/icons/preferences.svg
+++ b/plasma/desktoptheme/Arc-Dark/icons/preferences.svg
@@ -5,55 +5,13 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    viewBox="0 0 22 22"
    id="svg"
    version="1.1"
    inkscape:version="0.91 r13725"
    width="100%"
-   height="100%"
-   sodipodi:docname="preferences.svg">
-  <defs
-     id="defs81">
-    <style
-       id="current-color-scheme"
-       type="text/css">
-      .ColorScheme-Text {
-        color:#7B7C7E;
-      }
-      .ColorScheme-Background{
-        color:#EFF0F1;
-      }
-      .ColorScheme-Highlight{
-        color:#3DAEE6;
-      }
-      .ColorScheme-ViewText {
-        color:#7B7C7E;
-      }
-      .ColorScheme-ViewBackground{
-        color:#FCFCFC;
-      }
-      .ColorScheme-ViewHover {
-        color:#3DAEE6;
-      }
-      .ColorScheme-ViewFocus{
-        color:#1E92FF;
-      }
-      .ColorScheme-ButtonText {
-        color:#7B7C7E;
-      }
-      .ColorScheme-ButtonBackground{
-        color:#EFF0F1;
-      }
-      .ColorScheme-ButtonHover {
-        color:#3DAEE6;
-      }
-      .ColorScheme-ButtonFocus{
-        color:#1E92FF;
-      }
-</style>
-  </defs>
+   height="100%">
   <metadata
      id="metadata34">
     <rdf:RDF>
@@ -62,61 +20,23 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1600"
-     inkscape:window-height="805"
-     id="namedview32"
-     showgrid="true"
-     inkscape:zoom="3.24"
-     inkscape:cx="60.592077"
-     inkscape:cy="-55.587165"
-     inkscape:window-x="40"
-     inkscape:window-y="1050"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg"
-     borderlayer="true"
-     showguides="false"
-     inkscape:guide-bbox="true"
-     inkscape:snap-bbox="true"
-     inkscape:snap-nodes="true"
-     inkscape:snap-bbox-edge-midpoints="true"
-     inkscape:snap-global="true"
-     inkscape:bbox-nodes="true"
-     showborder="true">
-    <sodipodi:guide
-       orientation="0,1"
-       position="23,19"
-       id="guide3820" />
-    <sodipodi:guide
-       orientation="0,1"
-       position="24,3"
-       id="guide3822" />
-    <sodipodi:guide
-       orientation="1,0"
-       position="11,10"
-       id="guide3824" />
-    <sodipodi:guide
-       orientation="0,1"
-       position="21,11"
-       id="guide3826" />
-  </sodipodi:namedview>
+  <defs
+     id="defs7386">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+   .ColorScheme-Text { color:#d3dae3; } .ColorScheme-Highlight { color:#5294e2; } .ColorScheme-ButtonBackground { color:#d3dae3; }
+   </style>
+  </defs>
   <g
      id="preferences-system-bluetooth"
-     transform="translate(40,78)">
+     transform="translate(40,79)">
     <rect
-       style="fill:#ffffff;fill-opacity:0;stroke:none"
+       style="fill:#d3dae3;fill-opacity:0;stroke:none"
        id="rect3009"
        width="22"
        height="22"
@@ -125,12 +45,11 @@
     <path
        id="rect2996"
        d="m 11,4 0,6 -3,-3 0,2 3,3 -3,3 0,2 3,-3 0,6 2,-2 3,-3 -3,-3 3,-3 -3,-3 -2,-2 z m 1,3 2,2 -2,2 0,-4 z m 0,6 2,2 -2,2 0,-4 z"
-       style="fill:#d3dae3;fill-opacity:1;opacity:1"
-       inkscape:connector-curvature="0"
-       class="ColorScheme-Text" />
+       style="opacity:1;fill:#d3dae3;fill-opacity:1"
+       inkscape:connector-curvature="0" />
   </g>
   <g
-     transform="translate(80,78)"
+     transform="translate(80,79)"
      id="preferences-system-bluetooth-inactive">
     <rect
        y="1"
@@ -138,36 +57,34 @@
        height="22"
        width="22"
        id="rect3007"
-       style="fill:#ffffff;fill-opacity:0;stroke:none" />
+       style="fill:#d3dae3;fill-opacity:0;stroke:none" />
     <path
        inkscape:connector-curvature="0"
        style="opacity:0.3;fill:#d3dae3;fill-opacity:1"
        d="m 11,4 0,6 -3,-3 0,2 3,3 -3,3 0,2 3,-3 0,6 2,-2 3,-3 -3,-3 3,-3 -3,-3 -2,-2 z m 1,3 2,2 -2,2 0,-4 z m 0,6 2,2 -2,2 0,-4 z"
-       id="path3009"
-       class="ColorScheme-Text" />
+       id="path3009" />
   </g>
   <g
      id="preferences-system-bluetooth-activated"
-     transform="translate(0,78)">
+     transform="translate(0,79)">
     <rect
        y="1"
        x="1"
        height="22"
        width="22"
        id="rect3783"
-       style="fill:#ffffff;fill-opacity:0;stroke:none" />
+       style="fill:#d3dae3;fill-opacity:0;stroke:none" />
     <path
-       style="fill:#d3dae3;fill-opacity:1;opacity:1"
-       d="m 11,4 0,6 -3,-3 0,2 3,3 -3,3 0,2 3,-3 0,6 2,-2 3,-3 L 13,12 16,9 13,6 11,4 z M 4,5 C 3.4477153,5 3,5.4477153 3,6 3,6.5522847 3.4477153,7 4,7 4.5522847,7 5,6.5522847 5,6 5,5.4477153 4.5522847,5 4,5 z m 16,0 c -0.552285,0 -1,0.4477153 -1,1 0,0.5522847 0.447715,1 1,1 0.552285,0 1,-0.4477153 1,-1 0,-0.5522847 -0.447715,-1 -1,-1 z m -8,2 2,2 -2,2 0,-4 z m -8,4 c -0.5522847,0 -1,0.447715 -1,1 0,0.552285 0.4477153,1 1,1 0.5522847,0 1,-0.447715 1,-1 0,-0.552285 -0.4477153,-1 -1,-1 z m 16,0 c -0.552285,0 -1,0.447715 -1,1 0,0.552285 0.447715,1 1,1 0.552285,0 1,-0.447715 1,-1 0,-0.552285 -0.447715,-1 -1,-1 z m -8,2 2,2 -2,2 0,-4 z m -8,4 c -0.5522847,0 -1,0.447715 -1,1 0,0.552285 0.4477153,1 1,1 0.5522847,0 1,-0.447715 1,-1 0,-0.552285 -0.4477153,-1 -1,-1 z m 16,0 c -0.552285,0 -1,0.447715 -1,1 0,0.552285 0.447715,1 1,1 0.552285,0 1,-0.447715 1,-1 0,-0.552285 -0.447715,-1 -1,-1 z"
+       style="opacity:1;fill:#d3dae3;fill-opacity:1"
+       d="m 11,4 0,6 -3,-3 0,2 3,3 -3,3 0,2 3,-3 0,6 2,-2 3,-3 L 13,12 16,9 13,6 11,4 Z M 4,5 C 3.4477153,5 3,5.4477153 3,6 3,6.5522847 3.4477153,7 4,7 4.5522847,7 5,6.5522847 5,6 5,5.4477153 4.5522847,5 4,5 Z m 16,0 c -0.552285,0 -1,0.4477153 -1,1 0,0.5522847 0.447715,1 1,1 0.552285,0 1,-0.4477153 1,-1 0,-0.5522847 -0.447715,-1 -1,-1 z m -8,2 2,2 -2,2 0,-4 z m -8,4 c -0.5522847,0 -1,0.447715 -1,1 0,0.552285 0.4477153,1 1,1 0.5522847,0 1,-0.447715 1,-1 0,-0.552285 -0.4477153,-1 -1,-1 z m 16,0 c -0.552285,0 -1,0.447715 -1,1 0,0.552285 0.447715,1 1,1 0.552285,0 1,-0.447715 1,-1 0,-0.552285 -0.447715,-1 -1,-1 z m -8,2 2,2 -2,2 0,-4 z m -8,4 c -0.5522847,0 -1,0.447715 -1,1 0,0.552285 0.4477153,1 1,1 0.5522847,0 1,-0.447715 1,-1 0,-0.552285 -0.4477153,-1 -1,-1 z m 16,0 c -0.552285,0 -1,0.447715 -1,1 0,0.552285 0.447715,1 1,1 0.552285,0 1,-0.447715 1,-1 0,-0.552285 -0.447715,-1 -1,-1 z"
        id="path3785"
-       inkscape:connector-curvature="0"
-       class="ColorScheme-Text" />
+       inkscape:connector-curvature="0" />
   </g>
   <g
      id="preferences-desktop-display-randr"
      transform="translate(-1,-1)">
     <rect
-       style="fill:#ffffff;fill-opacity:0;stroke:none"
+       style="fill:#d3dae3;fill-opacity:0;stroke:none"
        id="rect3832"
        width="22"
        height="22"
@@ -175,49 +92,23 @@
        y="1" />
     <path
        id="rect7235"
-       style="color:#7b7c7e;opacity:1;fill:#d3dae3;fill-opacity:1;stroke:none"
+       style="fill:#d3dae3;fill-opacity:1;stroke:none"
        d="m 7.0000091,19.999986 10.0000179,0 0,1.000014 -10.0000179,0 z m 3.0000049,-1.999998 3.999994,0 0,1.999983 -3.999994,0 z M 2,4.0000055 2,17.999973 l 19.999999,0 0,-13.9999675 z m 0.9999988,0.999999 18.0000012,0 0,9.9999725 -18.0000012,0 z"
-       class="ColorScheme-Text"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccccccccccccccc" />
+       inkscape:connector-curvature="0" />
     <path
-       style="color:#7b7c7e;opacity:0.72000002;fill:#d3dae3;fill-opacity:1;stroke:none"
+       style="fill:#d3dae3;fill-opacity:1;stroke:none"
        d="m 4,10 4,4 -4,0 z"
        id="rect3018"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc"
-       class="ColorScheme-Text" />
+       inkscape:connector-curvature="0" />
     <path
-       class="ColorScheme-Text"
-       sodipodi:nodetypes="cccc"
        inkscape:connector-curvature="0"
        id="path3028"
        d="M 20,10 16,6 20,6 Z"
-       style="color:#7b7c7e;opacity:0.72000002;fill:#d3dae3;fill-opacity:1;stroke:none" />
+       style="fill:#d3dae3;fill-opacity:1;stroke:none" />
   </g>
-  <g
-     id="preferences-desktop-notification"
-     transform="translate(-1,39)">
-    <rect
-       y="1"
-       x="1"
-       height="22"
-       width="22"
-       id="rect3068"
-       style="fill:#ffffff;fill-opacity:0;stroke:none" />
-    <rect
-       style="fill:#db3c30;fill-opacity:1;stroke:none"
-       id="rect4130-82-0"
-       width="15.999978"
-       height="15.999987"
-       x="4.000011"
-       y="4"
-       ry="7.999989" />
-    <path
-       inkscape:connector-curvature="0"
-       style="fill:#fcfcfc;fill-opacity:1;stroke:none"
-       d="m 11.202644,7.1999826 -0.0026,7.2000124 1.599998,0 0.0026,-7.2000124 z m 0.799999,7.9999894 c -0.441822,0 -0.799999,0.358171 -0.799999,0.799999 0,0.441827 0.358177,0.799999 0.799999,0.799999 0.441822,0 0.799999,-0.358172 0.799999,-0.799999 0,-0.441828 -0.358177,-0.799999 -0.799999,-0.799999 z"
-       id="rect4142-6"
-       sodipodi:nodetypes="cccccsssss" />
-  </g>
+  <g id="preferences-desktop-notification">
+	<rect y="40" x="0" height="22" width="22" id="rect3068" style="opacity:0;fill:#d3dae3;fill-opacity:0.94117647;stroke:none"/>
+	<path id="path4238" d="m 11,43 c -4.418278,0 -8,3.581722 -8,8 0,4.418278 3.581722,8 8,8 4.418278,0 8,-3.581722 8,-8 0,-4.418278 -3.581722,-8 -8,-8 z" style="opacity:1;fill:#5294e2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+	<path id="path4173-0" d="M 10 47 L 10 53 L 12 53 L 12 47 L 10 47 z M 11 54 C 10.546848 54 10 54.518427 10 54.980469 C 10 55.442512 10.546848 56 11 56 C 11.453152 56 12 55.442512 12 54.980469 C 12 54.518427 11.453152 54 11 54 z" style="opacity:1;fill:#d3dae3;fill-opacity:0.94117647;stroke:none" />
+ </g>
 </svg>


### PR DESCRIPTION
Plasma theme was missing a preferences.svg icon, which is mainly used for bluetooth status. I've modified the icon from the KArc project (https://github.com/zbeptz/KArc-theme) to work with your theme if you want it.