### PR TITLE
Add Fedora to Third-party packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Packages in this section are not part of the official repositories. If you have 
 | Arch Linux | Marcus Behrendt | [arc-kde-git](https://aur.archlinux.org/packages/arc-kde-git) <sup>AUR</sup> |
 | Manjaro | Nikola Yanev | [arc-kde](http://download.tuxfamily.org/gericom/README.html) |
 | openSUSE | Konstantin Voinov | [arc-kde](https://software.opensuse.org/download.html?project=home:kill_it&package=arc-kde) <sup>OBS [[link](https://build.opensuse.org/package/show/home:kill_it/arc-kde)]</sub> |
+| Fedora | Robert-André Mauchin | `sudo dnf install arc-kde` <sup>[[link](https://src.fedoraproject.org/rpms/arc-kde)]</sup> |
 
 **<sup>[1]</sup>** This package does not contain Konversation themes.
 


### PR DESCRIPTION
I packaged arc-kde for Fedora (along Papirus Icon theme).
It still in updates-testing for now but should trickle down to the main repo in the next few days.